### PR TITLE
fix(website): error on section link click event

### DIFF
--- a/index.html
+++ b/index.html
@@ -918,7 +918,7 @@
                                     </div>
                                     <br />
                                     <br />
-                                    <button class="download_button" onclick="keyDown({key:'Digit0'})" tabindex="0">
+                                    <button class="download_button" onclick="keyDown({key:'Digit10'})" tabindex="0">
                                         Next section →
                                     </button>
                                 </div>

--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -129,10 +129,27 @@ function keyDown(e) {
     }
 
     if (!insideTextField || e.key == "Enter") {
-        const activeKey = !e.shiftKey
-            ? document.querySelector(`.key[data-key-code="${e.key}"]`)
-            : document.querySelector(`.key[data-key-code="Shift${e.key}"]`)
-        activeKey?.classList.add("active_key")
+        let activeKey
+
+        if (e.shiftKey) {
+            activeKey = document.querySelector(`.key[data-key-code="Shift${e.key}"]`)
+        } else {
+            activeKey =
+                document.querySelector(`.key[data-key-code="Digit${e.key}"]`) ??
+                document.querySelector(`.key[data-key-code="${e.key}"]`)
+        }
+
+        if (e.key.includes("Digit")) {
+            const digitMatch = e.key.match(/\d+/)
+            if (digitMatch) {
+                const extractedNumber = Number(digitMatch[0])
+                sectionNavigation(extractedNumber - 1)
+                return true
+            }
+            return false
+        }
+
+        if (activeKey) activeKey.classList.add("active_key")
 
         if (e.code.includes("Digit")) {
             sectionNavigation(+e.key == 0 ? 9 : +e.key - 1)


### PR DESCRIPTION
Hi, great typeface and website. 

While browsing this impressive website, I noticed that the section transition links, such as "Next section" are not functioning properly.

![CleanShot 2023-08-24 at 00 23 07](https://github.com/eigilnikolajsen/commit-mono/assets/92221103/6acf669f-4a2a-477d-972f-4557e3961771)

It seems the issue might be due to the absence of an event handler for the ```onclick="keyDown({key:'Digit~’})”``` set on the ```.download_button```. While the key action event is set up, this click event appears to be missing.

In this PR, I've made the following corrections:
• Ensured the ```onclick="keyDown({key:'Digit*’})”``` event functions correctly.
• Modified so that when the above is corrected, the ```.active_key``` class is added to ```data-key-code="Digit*"``` at the appropriate times. This also resolves the issue where the ```.active_key``` class wasn't added during key action events for ```data-key-code="Digit*"```.

(another approach could be to modify the onclick event itself)