### PR TITLE
[Website] Fix typos and missing words 

### DIFF
--- a/index.html
+++ b/index.html
@@ -878,7 +878,7 @@
                                             <ol>
                                                 <li>Uninstall the current version you have installed.</li>
                                                 <li>Install the new version.</li>
-                                                <li>Restart you IDE. The new version should show up.</li>
+                                                <li>Restart your IDE. The new version should show up.</li>
                                             </ol>
                                         </details>
                                         <details>

--- a/src/js/website_data.js
+++ b/src/js/website_data.js
@@ -166,7 +166,7 @@ Tip: Press <span class="span_key">+</span> and <span class="span_key">-</span> t
                         value: "%",
                         name: "percent",
                         description:
-                            "% (percent): The '%' is a quite wide symbol, so it will always look squashed in monospace. It fills all available space to more normal.",
+                            "% (percent): The '%' is a quite wide symbol, so it will always look squashed in monospace. It fills all available space to look more natural.",
                     },
                     {
                         value: "&",
@@ -184,7 +184,7 @@ Tip: Press <span class="span_key">+</span> and <span class="span_key">-</span> t
                         value: "-",
                         name: "hyphen",
                         description:
-                            "- Hyphen: The '-' is short but not too short. This is as it often works like a minus so it has to fit next to +.",
+                            "- Hyphen: The '-' is short but not too short. This is because it often works like a minus so it has to fit next to +.",
                     },
                     {
                         value: "(",


### PR DESCRIPTION
1. Addresses #97
2. Additionally changes the following:
    - Fixes "you" to "your" in **09 Docs**:

      <img width="399" alt="image" src="https://github.com/user-attachments/assets/a8e8bda6-253d-466c-8977-2adf9d5b2612">

    - Changes "as" to "because" for the hyphen explanation in **05 Code**

      
      <img width="405" alt="image" src="https://github.com/user-attachments/assets/652bc84f-c7e0-4acb-a807-47674af9b06d">

Caught these while re-downloading the font on a new machine. Thank you for the font!